### PR TITLE
[card-83183275] Experience section looking bad on mobile

### DIFF
--- a/components/sections/Experience.jsx
+++ b/components/sections/Experience.jsx
@@ -60,6 +60,19 @@ const Job = ({ id, place, icon, from, to, index }) => {
   );
 };
 
+const ExperienceTimeline = () => {
+  return (
+    <div className={styles.experience__timeline}>
+      <div className={styles.experience__pointer}>
+        <FaCarSide />
+      </div>
+      {jobs.map((job, i) => (
+        <Job {...job} key={i} index={i} />
+      ))}
+    </div>
+  );
+};
+
 const Experience = () => {
   return (
     <section id='experience' className={classNames(styles.experience, 'section section--light')}>
@@ -67,14 +80,7 @@ const Experience = () => {
         <h2 className='section__title'>
           <FormattedMessage id='experience.title' />
         </h2>
-        <div className={styles.experience__timeline}>
-          <div className={styles.experience__pointer}>
-            <FaCarSide />
-          </div>
-          {jobs.map((job, i) => (
-            <Job {...job} key={i} index={i} />
-          ))}
-        </div>
+        <ExperienceTimeline />
       </div>
     </section>
   );

--- a/styles/components/sections/Experience.module.scss
+++ b/styles/components/sections/Experience.module.scss
@@ -4,7 +4,11 @@
   &__timeline {
     position: relative;
     border: 1px solid $blue10;
-    margin: 4em 0 8em;
+    margin: 6em 0;
+
+    @include md {
+      margin: 4em 0 8em;
+    }
   }
 
   &__pointer {
@@ -45,6 +49,12 @@
     font-size: 0.75em;
     font-weight: bold;
     bottom: 100%;
+    text-align: center;
+    max-width: 6rem;
+
+    @include md {
+      max-width: none;
+    }
   }
 
   &__tooltip {
@@ -72,6 +82,14 @@
     ul {
       font-size: 0.6em;
       padding-left: 1em;
+    }
+
+    h4,
+    ul {
+      display: none;
+      @include md {
+        display: block;
+      }
     }
   }
 


### PR DESCRIPTION
Card: [HERE](https://github.com/cristianiniguez/cristianiniguez_website/projects/1#card-83183275)

# Description

- Experience timeline moved to a separated component
- Experience timeline styles improved

# Evidence

***MOBILE***
![image](https://user-images.githubusercontent.com/64929919/173686381-06e0481d-b4f5-4119-a2b8-7ee97d290f5c.png)
